### PR TITLE
Allow configuring serve image per rollout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,6 @@ services:
       - TRAINER_SPECS_PATH=/app/trainer-specs
       - MLFLOW_TRACKING_URI=http://mlflow:5000
       - DOCKER_HOST=http://socket-proxy:2375
-      - SERVE_IMAGE=server-sklearn-model-1:latest
     volumes:
       - router_state:/state
     ports:

--- a/router/README.txt
+++ b/router/README.txt
@@ -12,10 +12,14 @@ container images:
 
 ```yaml
 <trainer-name>:
-  trainer_image: example/trainer:latest   # default image when no selector is given
-  image_options:                          # optional selector -> image mapping
+  trainer_image: example/trainer:latest   # default trainer image when no selector is given
+  image_options:                          # optional selector -> trainer image mapping
     cpu: example/trainer:cpu
     gpu: example/trainer:cuda
+  serve_image: example/server:latest      # optional default serving runtime image
+  serve_image_options:                    # optional selector -> serving image mapping
+    cpu: example/server:cpu
+    gpu: example/server:cuda
   timeout: 1800
   gpus: "all"
   env:
@@ -44,5 +48,10 @@ Request body fields:
   `null` removes it from the final environment.
 
 Responses include the resolved `image_key` (or `null` when the default image was
-used) and any applied parameter overrides so logs and API clients can confirm
-how the trainer ran.
+used), the serving image that will be used for rollout, and any applied
+parameter overrides so logs and API clients can confirm how the trainer ran.
+
+The `POST /admin/roll` endpoint accepts an optional `serve_image` field when you
+want to override the runtime on a per-request basis. When the field is omitted,
+the router falls back to the serving image resolved from the trainer spec (or
+from the `SERVE_IMAGE` environment variable for backwards compatibility).

--- a/router/roll/api.py
+++ b/router/roll/api.py
@@ -13,6 +13,10 @@ class RollReq(BaseModel):
     name: str = Field(..., examples=["DiabetesRF"])
     ref: Union[str, int] = Field(..., examples=["@production", 17])
     wait_ready_seconds: int = Field(default=cfg.HEALTH_TIMEOUT_SEC, ge=1, le=900)
+    serve_image: str | None = Field(
+        default=None,
+        description="Optional serving image override. Falls back to configuration when omitted.",
+    )
 
 class RollResp(BaseModel):
     active: str
@@ -21,5 +25,10 @@ class RollResp(BaseModel):
 
 @router.post("/roll", response_model=RollResp)
 def roll(body: RollReq):
-    out = _svc.roll(name=body.name, ref=body.ref, wait_ready_seconds=body.wait_ready_seconds)
+    out = _svc.roll(
+        name=body.name,
+        ref=body.ref,
+        wait_ready_seconds=body.wait_ready_seconds,
+        serve_image=body.serve_image,
+    )
     return RollResp(**out)

--- a/router/roll/service.py
+++ b/router/roll/service.py
@@ -13,11 +13,18 @@ class RollService:
         self._admin_url = (proxy_admin_url or cfg.PROXY_ADMIN_URL).rstrip("/") + "/load"
 
     # --- public API ---
-    def roll(self, *, name: str, ref: Union[str, int], wait_ready_seconds: int) -> Dict[str, str]:
+    def roll(
+        self,
+        *,
+        name: str,
+        ref: Union[str, int],
+        wait_ready_seconds: int,
+        serve_image: str | None = None,
+    ) -> Dict[str, str]:
         target_uri = self._resolve_models_uri(name, ref)
 
         candidate_name = unique("serve-cand")
-        self._start_runtime(candidate_name, cfg.COMPOSE_NETWORK, target_uri)
+        self._start_runtime(candidate_name, cfg.COMPOSE_NETWORK, target_uri, serve_image=serve_image)
         cand_internal = f"http://{candidate_name}:{cfg.SERVE_PORT}"
 
         deadline = time.time() + wait_ready_seconds
@@ -57,14 +64,22 @@ class RollService:
             raise HTTPException(status_code=404, detail=f"model/alias not found: {e}")
         raise HTTPException(status_code=400, detail="ref must be '@alias' or integer version")
 
-    def _start_runtime(self, name: str, network: str, model_uri: str) -> str:
-        if not cfg.SERVE_IMAGE:
+    def _start_runtime(
+        self,
+        name: str,
+        network: str,
+        model_uri: str,
+        *,
+        serve_image: str | None = None,
+    ) -> str:
+        image = serve_image or cfg.SERVE_IMAGE
+        if not image:
             raise HTTPException(
                 status_code=500,
-                detail="SERVE_IMAGE is not configured; set SERVE_IMAGE or supply it via trainer specs.",
+                detail="Serving image not configured; supply serve_image via the request or trainer specs, or set SERVE_IMAGE.",
             )
         c = self._docker.containers.run(
-            image=cfg.SERVE_IMAGE,
+            image=image,
             name=name,
             detach=True,
             network=network,

--- a/router/trainer-specs/trainer-spec.yaml
+++ b/router/trainer-specs/trainer-spec.yaml
@@ -2,6 +2,9 @@ sklearn-model-1:
   trainer_image: trainer-sklearn-model-1:latest
   image_options:
     cpu: trainer-sklearn-model-1:latest
+  serve_image: server-sklearn-model-1:latest
+  serve_image_options:
+    cpu: server-sklearn-model-1:latest
   timeout: 1800
   env:
     MLFLOW_EXPERIMENT: diabetes_rf_demo

--- a/router/trainer/api.py
+++ b/router/trainer/api.py
@@ -32,6 +32,10 @@ class TrainResp(BaseModel):
     metrics: dict | None = None
     logs_tail: str | None = None
     image_key: str | None = Field(default=None, description="Image key used for the run.")
+    serve_image: str | None = Field(
+        default=None,
+        description="Serving image resolved for rolling out the produced model.",
+    )
     parameters: Dict[str, Any] | None = Field(
         default=None,
         description="Applied parameter overrides for the trainer run.",

--- a/router/trainer/service.py
+++ b/router/trainer/service.py
@@ -74,6 +74,7 @@ class TrainerService:
         gpus = spec.get("gpus")
         env = dict(spec.get("env") or {})
         env.setdefault("MLFLOW_TRACKING_URI", cfg.MLFLOW_TRACKING_URI)
+        serve_image = spec.get("selected_serve_image")
         
         # Apply parameter overrides if there's any in the request
         applied_parameters: Dict[str, Any] = {}
@@ -112,9 +113,9 @@ class TrainerService:
         print(
             "Starting trainer container "
             f"{name} "
-            f"(image={image}, image_key={image_key_for_log}, timeout={timeout}s, gpus={gpus}, "
+            f"(image={image}, image_key={image_key_for_log}, serve_image={serve_image}, timeout={timeout}s, gpus={gpus}, "
             f"parameters={applied_parameters or None})"
-        )        
+        )
         self._start_trainer(image=image, env=env, network=cfg.COMPOSE_NETWORK, name=name, gpus=gpus)
         status, logs = self._wait_trainer(name, timeout)
 
@@ -131,6 +132,7 @@ class TrainerService:
             "metrics": None,
             "image_key": selected_image_key,
             "parameters": applied_parameters or None,
+            "serve_image": serve_image,
         }
 
         if status != 0 or version is None:
@@ -169,7 +171,12 @@ class TrainerService:
         if not version or not model_name:
             raise HTTPException(status_code=500, detail="missing registered_model/version after training")
         try:
-            roll_out = self._roll.roll(name=model_name, ref=version, wait_ready_seconds=cfg.HEALTH_TIMEOUT_SEC)
+            roll_out = self._roll.roll(
+                name=model_name,
+                ref=version,
+                wait_ready_seconds=cfg.HEALTH_TIMEOUT_SEC,
+                serve_image=train_resp.get("serve_image"),
+            )
             return {**train_resp, "rolled": True, "public_url": roll_out.get("public_url")}
         except HTTPException as e:
             return {**train_resp, "rolled": False, "logs_tail": f"roll failed: {e.detail}"}
@@ -256,9 +263,29 @@ class TrainerService:
                     ),
                 },
             )
+        serve_options_raw = spec.get("serve_image_options") or {}
+        if serve_options_raw and not isinstance(serve_options_raw, dict):
+            raise HTTPException(
+                status_code=500,
+                detail=
+                {
+                    "error": "serve_image_options must be a mapping",
+                    "trainer": trainer,
+                    "image_key": image_key,
+                },
+            )
+        serve_options = dict(serve_options_raw) if isinstance(serve_options_raw, dict) else {}
+        default_serve_image = spec.get("serve_image") or cfg.SERVE_IMAGE
+        selected_serve_image = default_serve_image
+        if image_key and image_key in serve_options:
+            selected_serve_image = serve_options[image_key]
+
         spec["trainer_image"] = selected_image
         spec["image_options"] = options
         spec["selected_image_key"] = image_key
+        spec["serve_image"] = default_serve_image
+        spec["serve_image_options"] = serve_options
+        spec["selected_serve_image"] = selected_serve_image
 
         # Normalize gpus field
         if "gpus" in spec and spec["gpus"] not in (None, ""):


### PR DESCRIPTION
## Summary
- allow /admin/roll requests to supply a serving image override and fall back to configuration only when needed
- resolve serving images from trainer specs and propagate them through train/train_then_roll responses and rollouts
- document the new spec fields and remove the SERVE_IMAGE requirement from the docker-compose example

## Testing
- python -m compileall roll trainer

------
https://chatgpt.com/codex/tasks/task_e_68d4e1dd1c90832badf2bad3dc15e26d